### PR TITLE
Update user detail

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-config-next": "12.2.3",
     "ky": "^0.31.1",
     "postcss": "^8.4.16",
+    "react-icons": "^4.4.0",
     "tailwindcss": "^3.1.8",
     "typescript": "4.7.4"
   }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -19,3 +19,9 @@ export const getUser = async (id: number) => {
 export const getPosts = async () => {
   return await ky.get(`${getApiUrl("/posts")}`).json<Post[]>();
 };
+
+export const getAlbums = async (userId: number) => {
+  return await ky
+    .get(`${getApiUrl(`/albums?userId=${userId}`)}`)
+    .json<Post[]>();
+};

--- a/src/components/AlbumList/index.tsx
+++ b/src/components/AlbumList/index.tsx
@@ -1,0 +1,47 @@
+import classNames from "classnames";
+import { useEffect, useState } from "react";
+import { getAlbums } from "../../api";
+import { Album } from "../../types/Album";
+
+const AlbumList = ({ userId }: { userId: number }) => {
+  const [albumList, setAlbumList] = useState<Album[]>([]);
+
+  const getAlbumsByUserId = async (id: number) => {
+    const albums = await getAlbums(id);
+    setAlbumList(albums);
+  };
+
+  useEffect(() => {
+    getAlbumsByUserId(userId);
+  }, [userId]);
+
+  return (
+    <div className="mt-4">
+      <div className="font-bold text-2xl mb-3">Albums</div>
+      <div className="flex flex-wrap">
+        {albumList.map((it, idx) => (
+          <div
+            key={it.id}
+            className={classNames(
+              "flex flex-row items-center",
+              "rounded-lg",
+              "bg-indigo-100",
+              "w-80 h-20",
+              "p-2",
+              "mr-4 mb-2",
+              "last:mr-0 last:mb-0",
+              "text-ellipsis overflow-hidden"
+            )}
+          >
+            <div className="rounded-full bg-indigo-400 w-7 h-7 flex items-center justify-center mr-3">
+              {idx + 1}
+            </div>
+            {it.title}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AlbumList;

--- a/src/components/BackButton/index.tsx
+++ b/src/components/BackButton/index.tsx
@@ -1,0 +1,16 @@
+import { useRouter } from "next/router";
+import { BiLeftArrowAlt } from "react-icons/bi";
+
+const BackButton = ({ url }: { url: string }) => {
+  const router = useRouter();
+
+  return (
+    <button
+      className="hover:bg-blue-400 hover:text-white rounded-lg w-8 h-8 mr-2"
+      onClick={() => router.push({ pathname: url })}
+    >
+      <BiLeftArrowAlt />
+    </button>
+  );
+};
+export default BackButton;

--- a/src/components/ContentTitle/index.tsx
+++ b/src/components/ContentTitle/index.tsx
@@ -2,7 +2,7 @@ const ContentTitle: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   return (
-    <div className="font-bold text-3xl mb-3 border-b-2 border-gray-700 leading-[1.6]">
+    <div className="flex items-center font-bold text-3xl text-gray-600 mb-3 border-b-2 border-gray-600 leading-[1.6]">
       {children}
     </div>
   );

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -5,11 +5,6 @@ const Menu = () => {
     <div className="w-72 h-screen flex flex-col p-4 bg-gray-700 text-white">
       <MenuItem name="Next SSR Sample" pathname="/" className="mb-6 text-3xl" />
       <MenuItem name="User List" pathname="/users" />
-      <MenuItem
-        name="User Detail #1"
-        pathname="/users/[id]"
-        query={{ id: 1 }}
-      />
       <MenuItem name="Post List" pathname="/posts" />
       <MenuItem
         name="Post Detail #1"

--- a/src/pages/posts/[id]/index.tsx
+++ b/src/pages/posts/[id]/index.tsx
@@ -1,4 +1,5 @@
 import { useRouter } from "next/router";
+import BackButton from "../../../components/BackButton";
 import ContentTitle from "../../../components/ContentTitle";
 import Menu from "../../../components/Menu";
 import ContentContainer from "../../../containers/ContentContainer";
@@ -11,7 +12,10 @@ const PostDetail = () => {
     <PageContainer>
       <Menu />
       <ContentContainer>
-        <ContentTitle>Post Detail</ContentTitle>
+        <ContentTitle>
+          <BackButton url="/posts" />
+          Post Detail
+        </ContentTitle>
         <div>Post : {id}</div>
       </ContentContainer>
     </PageContainer>

--- a/src/pages/users/[id]/index.tsx
+++ b/src/pages/users/[id]/index.tsx
@@ -1,5 +1,7 @@
 import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { getUser } from "../../../api";
+import AlbumList from "../../../components/AlbumList";
+import BackButton from "../../../components/BackButton";
 import ContentTitle from "../../../components/ContentTitle";
 import Menu from "../../../components/Menu";
 import ContentContainer from "../../../containers/ContentContainer";
@@ -15,9 +17,17 @@ const UserDetail = ({
     <PageContainer>
       <Menu />
       <ContentContainer>
-        <ContentTitle>User Detail</ContentTitle>
-        <div></div>
-        <div>Usear Detail: {user.name}</div>
+        <ContentTitle>
+          <BackButton url="/users" />
+          User Detail
+        </ContentTitle>
+        <div className="p-4">
+          <div className="text-4xl font-bold mb-2">{user.name}</div>
+          <div className="italic text-gray-600">{user.email}</div>
+          <div className="italic text-gray-600">{user.phone}</div>
+          <div>{`${user.address.suite} ${user.address.street} ${user.address.city} (${user.address.zipcode})`}</div>
+          <AlbumList userId={user.id} />
+        </div>
       </ContentContainer>
     </PageContainer>
   );

--- a/src/types/Album.ts
+++ b/src/types/Album.ts
@@ -1,0 +1,5 @@
+export interface Album {
+  userId: number;
+  id: number;
+  title: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,6 +1663,11 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-icons@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.4.0.tgz#a13a8a20c254854e1ec9aecef28a95cdf24ef703"
+  integrity sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
user detail 정보가 표시될 수 있도록 페이지 내용을 수정합니다.

user detail 정보에  사용자 이름, email, 전화번호, 주소 등이 표시될 수 있도록 구성하였고, user Id를 사용하여 선택된 사용자의 album 목록을 표시할 수 있도록 수정했습니다.

이번 작업하면서 일부 component의 마이너한 스타일 작업도 같이 추가되었습니다.

user list에서 사용자 정보 클릭하여 detail로 넘어갈 수 있기 때문에 menu에서 user detail sample은 삭제했습니다.
해당 기능삭제하면서 detail페이지에서 상위 페이지로 이동할 수 있는 back button을 추가합니다.